### PR TITLE
fix: migrate melos to 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 build/
 # If you're building an application, you may want to check-in your pubspec.lock
 pubspec.lock
-
+pubspec_overrides.yaml
 # Directory created by dartdoc
 # If you don't generate documentation locally you can remove this line.
 doc/api/

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,4 +1,4 @@
 name: at_services
 
 packages:
-  - packages/*
+  - packages/**

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,4 +1,4 @@
 name: at_services
 
 packages:
-  - packages/**
+  - packages/*

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,7 @@
+name: at_services_workspace
+
+environment:
+  sdk: ">=2.18.0 <4.0.0"
+
+dev_dependencies:
+  melos: ^3.0.1


### PR DESCRIPTION
**- What I did**
Melos needs a pubspec and has some formatting changes in melos.yaml.
Added pubspec_overrides.yaml to .gitignore
**- How I did it**

**- How to verify it**

**- Description for the changelog**
migrate melos from 2.0 to 3.0