### PR TITLE
ci: Workflows to sync certs and automate build of at_proxyserver Docker image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "docker"
+    directory: "/packages/at_secondary_proxy/"
+    schedule:
+      interval: "daily"
+    groups:
+      docker:
+        patterns:
+          - "*"
+  - package-ecosystem: "pub"
+    directory: "/packages/at_secondary_proxy/"
+    schedule:
+      interval: "daily"
+    groups:
+      pub:
+        patterns:
+          - "*"

--- a/.github/workflows/proxy_rebuild.yaml
+++ b/.github/workflows/proxy_rebuild.yaml
@@ -1,0 +1,45 @@
+name: proxy_rebuild
+# Creates a new image for atsigncompany/at_proxyserver whenever updated
+# certificates are merged to trunk
+on:
+  push:
+    branches:
+      - trunk
+    paths:
+      - 'packages/at_secondary_proxy/certs/cert.pem'
+  workflow_dispatch:
+
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
+jobs:
+  at_proxyserver:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trunk
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push at_proxyserver
+        id: docker_build_proxy
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          file: packages/at_secondary_proxy/tools/Dockerfile
+          push: true
+          tags: |
+            atsigncompany/at_proxyserver:latest
+            atsigncompany/at_proxyserver:gha${{ github.run_number }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8

--- a/.github/workflows/refreshcerts.yaml
+++ b/.github/workflows/refreshcerts.yaml
@@ -1,0 +1,69 @@
+name: Refreshcerts
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '43 12 * * *' # At 1243 each day
+
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
+jobs:
+  checkcert:
+    runs-on: ubuntu-latest
+    outputs:
+      cert: ${{ steps.checkcert.outputs.cert }}
+    steps:
+      - name: checkout repo content
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - id: checkcert
+        name: Check for new cert
+        run: |
+          cd packages/at_secondary_proxy/certs/
+          CERTURL='https://raw.githubusercontent.com/atsign-foundation/at_server/trunk/tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs/cert.pem'
+          wget -O cert.pem ${CERTURL}
+          if [ -z "$(git status --porcelain)" ]; then
+            echo 'No new cert'
+            echo "cert=NOTNEW" >> $GITHUB_OUTPUT
+          else
+            echo "cert=NEW" >> $GITHUB_OUTPUT
+          fi
+
+  update_cert_in_repo:
+    needs: [checkcert]
+    if: ${{ needs.checkcert.outputs.cert == 'NEW' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout_to_update_version
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Update stable version
+        id: getcert
+        run: |
+          cd packages/at_secondary_proxy/certs/
+          CERTBASE='https://raw.githubusercontent.com/atsign-foundation/at_server/trunk/tools/build_virtual_environment/ve_base/contents/atsign/secondary/base/certs'
+          wget -O cacert.pem ${CERTBASE}/cacert.pem
+          wget -O cert.pem ${CERTBASE}/cert.pem
+          wget -O fullchain.pem ${CERTBASE}/fullchain.pem
+          wget -O privkey.pem ${CERTBASE}/privkey.pem
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.MY_GITHUB_TOKEN }}
+          commit-message: 'chore: Update certs'
+          committer: library-action[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: library-action[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          signoff: false
+          add-paths: .
+          branch: bot-new-cert
+          delete-branch: true
+          title: 'chore: Update certs'
+          body: |
+            New certs copied from at_server
+          labels: |
+            operations
+          assignees: cpswan
+          reviewers: gkc
+          draft: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,22 +37,22 @@ describe. The atsign-foundation GitHub organization's conventions and configurat
 
 To prepare your dedicated GitHub repository:
 
-1. Fork in GitHub https://github.com/atsign-foundation/REPO
-2. Clone *your forked repository* (e.g., `git clone git@github.com:yourname/REPO`)
+1. Fork in GitHub https://github.com/atsign-foundation/at_services
+2. Clone *your forked repository* (e.g., `git clone git@github.com:yourname/at_services`)
 3. Set your remotes as follows:
 
    ```sh
-   cd REPO
-   git remote add upstream git@github.com:atsign-foundation/REPO.git
+   cd at_services
+   git remote add upstream git@github.com:atsign-foundation/at_services.git
    git remote set-url upstream --push DISABLED
    ```
 
    Running `git remote -v` should give something similar to:
 
    ```text
-   origin  git@github.com:yourname/REPO.git (fetch)
-   origin  git@github.com:yourname/REPO.git (push)
-   upstream        git@github.com:atsign-foundation/REPO.git (fetch)
+   origin  git@github.com:yourname/at_services.git (fetch)
+   origin  git@github.com:yourname/at_services.git (push)
+   upstream        git@github.com:atsign-foundation/at_services.git (fetch)
    upstream        DISABLED (push)
    ```
 
@@ -96,10 +96,10 @@ To prepare your dedicated GitHub repository:
 1. Open a new Pull Request to the main repository using your `trunk` branch
 
 
-## @‎library release process
+## at_library release process
 
 The Atsign Foundation produces several widgets and libraries that the app developer
-can make use of to develop apps on @‎protocol. These libraries are developed in
+can make use of to develop apps on at_protocol. These libraries are developed in
 Dart & Flutter and published to [pub.dev](https://pub.dev/publishers/atsign.org/packages).
 
 ![alt_text](images/image1.png "Version flow")
@@ -121,7 +121,7 @@ chronological order.
 ## Reporting a bug
 
 The best place to start reporting bugs on the libraries published by
-@‎protocol would be the “View/report issues” link available on
+at_protocol would be the “View/report issues” link available on
 [pub.dev](https://pub.dev/publishers/atsign.org/packages).
 
 ![alt_text](images/image4.png "View/report issues highlight")

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,137 @@
+<a href="https://atsign.com#gh-light-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only" alt="The Atsign Foundation"></a><a href="https://atsign.com#gh-dark-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2023/08/atsign-logo-horizontal-reverse2022-Color.svg#gh-dark-mode-only" alt="The Atsign Foundation"></a>
+
+# The Atsign Foundation Code of Conduct
+
+Based on
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](code_of_conduct.md)
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+conduct@atsign.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+Community Impact Guidelines were inspired by 
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available 
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/packages/at_secondary_proxy/README.md
+++ b/packages/at_secondary_proxy/README.md
@@ -1,4 +1,4 @@
-<img width=250px src="https://atsign.dev/assets/img/@platform_logo_grey.svg?sanitize=true" alt="AtPlatform logo, grey, svg">
+<a href="https://atsign.com#gh-light-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only" alt="The Atsign Foundation"></a><a href="https://atsign.com#gh-dark-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2023/08/atsign-logo-horizontal-reverse2022-Color.svg#gh-dark-mode-only" alt="The Atsign Foundation"></a>
 
 ## at_secondary_proxy
 

--- a/packages/at_secondary_proxy/tools/Dockerfile
+++ b/packages/at_secondary_proxy/tools/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile
 # Build image for a containerized call of the at_proxyserver binary in scratch container
 # default certs included but mount /atsign/certs for certs and caroot
-FROM dart:3.7.3@sha256:1d0491432892b4f7cd216dfaf8406adef5bff216adc51a024e381023d8f22ce7  AS buildimage
+FROM dart:3.8.2@sha256:660a0751a021250d588af61322ab2cce9edef6002960638a4b0c09ede7427b99 AS buildimage
 ENV PACKAGEDIR=packages/at_secondary_proxy
 ENV HOMEDIR=/atsign
 ENV WORKDIR=/app


### PR DESCRIPTION
Fixes #13 

**- What I did**

* docs: Boilerplate fixes
* build(deps): Dependabot config for actions, Docker and Dart
* ci: Workflow to update certs
* build(deps): Bump Dart to latest stable
* ci: Workflow to automate build of at_proxyserver Docker image

**- How I did it**

Based on workflows in at_client_sdk and at_server

**- How to verify it**

Once merged run the refresh_certs workflow, which should then spawn the proxy_rebuild workflow once new certs are merged.

**- Description for the changelog**

ci: Workflows to sync certs and automate build of at_proxyserver Docker image
