### PR TITLE
fix: use `SecurityContext.defaultContext` instead of `SecurityContext()`

### DIFF
--- a/packages/at_secondary_proxy/lib/src/secondary_proxy_server.dart
+++ b/packages/at_secondary_proxy/lib/src/secondary_proxy_server.dart
@@ -24,7 +24,7 @@ class SecondaryProxyServer {
   SecondaryProxyServer(this.proxyUrl, this.proxyPort, this.bindPort, this.secondaryAddressFinder);
 
   void startServing() {
-    var secCon = SecurityContext();
+    var secCon = SecurityContext.defaultContext;
 
     secCon.useCertificateChain(_certificateChainLocation);
     secCon.usePrivateKey(_privateKeyLocation);


### PR DESCRIPTION
**- What I did**
fix: use `SecurityContext.defaultContext` instead of `SecurityContext()`

Ensures that we pick up everything from the system as well as whatever other certs we add. See https://api.flutter.dev/flutter/dart-io/SecurityContext/defaultContext.html
