### PR TITLE
fix: Dependabot path for Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "docker"
-    directory: "/packages/at_secondary_proxy/"
+    directory: "/packages/at_secondary_proxy/tools/"
     schedule:
       interval: "daily"
     groups:


### PR DESCRIPTION
Dependabot isn't finding Dockerfile

**- What I did**

Corrected path

**- How I did it**

Added `tools/`

**- How to verify it**

Look at Insights > Dependency graph > Dependabot once merged

**- Description for the changelog**

fix: Dependabot path for Dockerfile
