### PR TITLE
ci: Run workflow when bump to Dockerfile

### DIFF
--- a/.github/workflows/proxy_rebuild.yaml
+++ b/.github/workflows/proxy_rebuild.yaml
@@ -1,12 +1,13 @@
 name: proxy_rebuild
 # Creates a new image for atsigncompany/at_proxyserver whenever updated
-# certificates are merged to trunk
+# certificates are merged to trunk or if Dockerfile is bumped
 on:
   push:
     branches:
       - trunk
     paths:
       - 'packages/at_secondary_proxy/certs/cert.pem'
+      - 'packages/at_secondary_proxy/tools/Dockerfile'
   workflow_dispatch:
 
 permissions:  # added using https://github.com/step-security/secure-workflows


### PR DESCRIPTION
Workflow was set to run when certs are updated, but it should also update the image when we bump the Dockerfile

**- What I did**

Added another path

**- How to verify it**

Will need to wait for next Dart bump

**- Description for the changelog**

ci: Run workflow when bump to Dockerfile