### PR TITLE
ci: Add SLSA attestation to build workflow

### DIFF
--- a/.github/workflows/proxy_rebuild.yaml
+++ b/.github/workflows/proxy_rebuild.yaml
@@ -16,22 +16,23 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   at_proxyserver:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+      contents: read
+      attestations: write
     steps:
       - name: Checkout trunk
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-
       - name: Login to DockerHub
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Build and push at_proxyserver
         id: docker_build_proxy
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -44,3 +45,10 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64/v8
+      - name: Attest
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        id: attest
+        with:
+          subject-name: index.docker.io/atsigncompany/at_proxyserver
+          subject-digest: ${{ steps.docker_build_proxy.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/proxy_rebuild.yaml
+++ b/.github/workflows/proxy_rebuild.yaml
@@ -16,11 +16,8 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   at_proxyserver:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      packages: write
-      contents: read
-      attestations: write
+    outputs:
+      digest: ${{ steps.docker_build_proxy.outputs.digest }}
     steps:
       - name: Checkout trunk
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -45,10 +42,17 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64/v8
-      - name: Attest
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
-        id: attest
-        with:
-          subject-name: index.docker.io/atsigncompany/at_proxyserver
-          subject-digest: ${{ steps.docker_build_proxy.outputs.digest }}
-          push-to-registry: true
+
+  slsa_provenance:
+    needs: [at_proxyserver]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: "atsigncompany/at_proxyserver"
+      digest: ${{ needs.at_proxyserver.outputs.digest }}
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![gitHub license](https://img.shields.io/badge/license-BSD3-blue.svg)](../LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_services/badge)](https://securityscorecards.dev/viewer/?uri=github.com/atsign-foundation/at_services&sort_by=check-score&sort_direction=desc)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11022/badge)](https://www.bestpractices.dev/projects/11022)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 
 # The atPlatform ancillary services
 

--- a/packages/at_secondary_proxy/README.md
+++ b/packages/at_secondary_proxy/README.md
@@ -73,6 +73,22 @@ All of our software is open with intent. We welcome contributions - we want
 pull requests, and we want to hear about issues. See also
 [CONTRIBUTING.md](../../CONTRIBUTING.md)
 
-## changelog
+## Change log
 
 Changes are logged in the [CHANGELOG.md](CHANGELOG.md) file
+
+## SLSA
+
+The Docker images created from this repo have SLSA Build Level 3 attestations.
+
+These can be verified using the
+[slsa-verifier](https://github.com/slsa-framework/slsa-verifier) tool e.g.:
+
+```sh
+TAG="latest"
+IMAGE="atsigncompany/at_proxyserver"
+SHA=$(docker buildx imagetools inspect ${IMAGE}:${TAG} \
+  --format "{{json .Manifest}}" | jq -r .digest)
+slsa-verifier verify-image ${IMAGE}@${SHA} --source-uri \
+  github.com/atsign-foundation/at_server
+```


### PR DESCRIPTION
As the main output of this repo is a Docker image we should have a SLSA attestation for it to complement the other aspects of supply chain security.

**- What I did**

* Added slsa job to workflow
* Added SLSA badge to root readme
* Added SLSA verification details to package readme

**- How I did it**

Based on at_c_buildimage workflow

**- How to verify it**

Already build an image against this branch, so the SLSA attestation is there and can be tested with:

```sh
TAG="gha6"
IMAGE="atsigncompany/at_proxyserver"
SHA=$(docker buildx imagetools inspect ${IMAGE}:${TAG} \
  --format "{{json .Manifest}}" | jq -r .digest)
slsa-verifier verify-image ${IMAGE}@${SHA} --source-uri \
  github.com/atsign-foundation/at_services
```

**- Description for the changelog**

ci: Add SLSA attestation to build workflow
