### PR TITLE
fix: removed flush in listen to prevent breaking during concurrent calls

### DIFF
--- a/packages/at_secondary_proxy/lib/src/secondary_connection_bridge.dart
+++ b/packages/at_secondary_proxy/lib/src/secondary_connection_bridge.dart
@@ -22,8 +22,7 @@ class SecondaryConnectionBridge {
 
   late String _atSign;
 
-  String get atSign => _atSign;
-  
+
   SecondaryConnectionBridge(this.proxyUrl, this._clientSocket, this._secondaryAddressFinder) {
     _clientSocket.listen(_clientOnData, onDone: _clientOnDone, onError: _clientOnError);
     _clientSocket.done.onError((error, stackTrace) => (_clientOnError(error)));

--- a/packages/at_secondary_proxy/lib/src/secondary_connection_bridge.dart
+++ b/packages/at_secondary_proxy/lib/src/secondary_connection_bridge.dart
@@ -22,6 +22,8 @@ class SecondaryConnectionBridge {
 
   late String _atSign;
 
+  String get atSign => _atSign;
+  
   SecondaryConnectionBridge(this.proxyUrl, this._clientSocket, this._secondaryAddressFinder) {
     _clientSocket.listen(_clientOnData, onDone: _clientOnDone, onError: _clientOnError);
     _clientSocket.done.onError((error, stackTrace) => (_clientOnError(error)));
@@ -84,7 +86,6 @@ class SecondaryConnectionBridge {
           try {
             _logger.info("Writing command $command plus \\n");
             _secondarySocket.write('$command\n');
-            await _secondarySocket.flush();
 
             _logger.info("Bridge is open");
             _state = BridgeState.open;
@@ -97,7 +98,6 @@ class SecondaryConnectionBridge {
         break;
       case BridgeState.open:
         _secondarySocket.add(data);
-        await (_secondarySocket.flush());
         break;
       case BridgeState.closing:
         // Nothing to do here
@@ -116,7 +116,6 @@ class SecondaryConnectionBridge {
         break;
       case BridgeState.open:
         _clientSocket.add(data);
-        await (_clientSocket.flush());
         break;
       case BridgeState.closing:
         // Nothing to do here

--- a/packages/at_secondary_proxy/lib/src/secondary_connection_bridge.dart
+++ b/packages/at_secondary_proxy/lib/src/secondary_connection_bridge.dart
@@ -12,19 +12,25 @@ class SecondaryConnectionBridge {
   late SecureSocket _secondarySocket;
   final String proxyUrl;
 
-  static final AtSignLogger _initialLogger = AtSignLogger('SecondaryConnectionBridge');
+  static final AtSignLogger _initialLogger =
+      AtSignLogger('SecondaryConnectionBridge');
 
   AtSignLogger _logger = _initialLogger;
 
   BridgeState _state = BridgeState.opening;
 
+  final SocketCreator _socketCreator;
+
   final SecondaryAddressFinder _secondaryAddressFinder;
 
   late String _atSign;
 
-
-  SecondaryConnectionBridge(this.proxyUrl, this._clientSocket, this._secondaryAddressFinder) {
-    _clientSocket.listen(_clientOnData, onDone: _clientOnDone, onError: _clientOnError);
+  SecondaryConnectionBridge(
+      this.proxyUrl, this._clientSocket, this._secondaryAddressFinder,
+      {SocketCreator? socketCreator})
+      : _socketCreator = socketCreator ?? DefaultSocketCreator() {
+    _clientSocket.listen(_clientOnData,
+        onDone: _clientOnDone, onError: _clientOnError);
     _clientSocket.done.onError((error, stackTrace) => (_clientOnError(error)));
 
     _logger.info("Sending @ prompt; started listening on new client socket");
@@ -64,7 +70,8 @@ class SecondaryConnectionBridge {
           late SecondaryAddress secondaryAddress;
           try {
             _logger.info("Looking up secondary for $_atSign");
-            secondaryAddress = await _secondaryAddressFinder.findSecondary(_atSign);
+            secondaryAddress =
+                await _secondaryAddressFinder.findSecondary(_atSign);
           } catch (e) {
             await _writeStringAndClose(e.toString());
             return;
@@ -73,14 +80,17 @@ class SecondaryConnectionBridge {
           // connect to the secondary
           try {
             _logger.info("Connecting to $secondaryAddress");
-            _secondarySocket = await SecureSocket.connect(secondaryAddress.host, secondaryAddress.port);
+            _secondarySocket = await _socketCreator.create(
+                secondaryAddress.host, secondaryAddress.port);
           } catch (e) {
             await _writeStringAndClose(e.toString());
             return;
           }
           _logger.info("Setting up secondary socket listen");
-          _secondarySocket.listen(_secondaryOnData, onDone: _secondaryOnDone, onError: _secondaryOnError);
-          unawaited(_secondarySocket.done.onError((error, stackTrace) => (_clientOnError(error))));
+          _secondarySocket.listen(_secondaryOnData,
+              onDone: _secondaryOnDone, onError: _secondaryOnError);
+          unawaited(_secondarySocket.done
+              .onError((error, stackTrace) => (_clientOnError(error))));
 
           try {
             _logger.info("Writing command $command plus \\n");
@@ -111,7 +121,8 @@ class SecondaryConnectionBridge {
     switch (_state) {
       case BridgeState.opening:
         // Should not be possible
-        _logger.severe("_serverMessageHandler called while BridgeState is $_state");
+        _logger.severe(
+            "_serverMessageHandler called while BridgeState is $_state");
         break;
       case BridgeState.open:
         _clientSocket.add(data);
@@ -204,5 +215,15 @@ class SecondaryConnectionBridge {
     }
     // ignore: empty_catches
     catch (ignore) {}
+  }
+}
+
+abstract interface class SocketCreator {
+  Future<SecureSocket> create(String host, int port);
+}
+class DefaultSocketCreator implements SocketCreator {
+  @override
+  Future<SecureSocket> create(String host, int port) {
+    return SecureSocket.connect(host, port);
   }
 }

--- a/packages/at_secondary_proxy/lib/src/secondary_proxy_server.dart
+++ b/packages/at_secondary_proxy/lib/src/secondary_proxy_server.dart
@@ -21,7 +21,8 @@ class SecondaryProxyServer {
   bool _running = false;
   bool get running => _running;
 
-  SecondaryProxyServer(this.proxyUrl, this.proxyPort, this.bindPort, this.secondaryAddressFinder);
+  SecondaryProxyServer(this.proxyUrl, this.proxyPort, this.bindPort,
+      this.secondaryAddressFinder);
 
   void startServing() {
     var secCon = SecurityContext.defaultContext;
@@ -30,7 +31,8 @@ class SecondaryProxyServer {
     secCon.usePrivateKey(_privateKeyLocation);
     secCon.setTrustedCertificates(_trustedCertificateLocation);
 
-    SecureServerSocket.bind(InternetAddress.anyIPv4, bindPort, secCon, requestClientCertificate: true)
+    SecureServerSocket.bind(InternetAddress.anyIPv4, bindPort, secCon,
+            requestClientCertificate: true)
         .then((SecureServerSocket secureServerSocket) {
       logger.info('Secure Socket listening on port $bindPort');
       _secureServerSocket = secureServerSocket;

--- a/packages/at_secondary_proxy/pubspec.lock
+++ b/packages/at_secondary_proxy/pubspec.lock
@@ -361,6 +361,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.5.1"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   mutex:
     dependency: transitive
     description:

--- a/packages/at_secondary_proxy/pubspec.yaml
+++ b/packages/at_secondary_proxy/pubspec.yaml
@@ -3,7 +3,7 @@ description: A reverse proxy through which clients can connect to secondary serv
 version: 1.0.1
 
 environment:
-  sdk: '>=2.16.2 <3.0.0'
+  sdk: '>=3.0.0'
 
 
 dependencies:
@@ -15,3 +15,4 @@ dev_dependencies:
   lints: ^6.0.0
   test: ^1.26.3
   mockito: ^5.5.0
+  mocktail: ^1.0.4

--- a/packages/at_secondary_proxy/test/lib/mock/mocks.dart
+++ b/packages/at_secondary_proxy/test/lib/mock/mocks.dart
@@ -4,8 +4,7 @@ import 'dart:typed_data';
 
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_secondary_proxy/src/secondary_connection_bridge.dart';
-import 'package:mockito/mockito.dart';
-
+import 'package:mocktail/mocktail.dart';
 // Lightweight hand-written mocks so we can control listen/done behavior in unit tests.
 class SecureSocketMock extends Mock implements SecureSocket {
   final StreamController<Uint8List> _controller = StreamController<Uint8List>();
@@ -37,6 +36,12 @@ class SecureSocketMock extends Mock implements SecureSocket {
       cancelOnError: cancelOnError,
     );
   }
+
+  @override
+  Future<dynamic> flush(){
+    return _controller.addStream(_controller.stream);
+  }
+  
 
   Future<void> closeController() async {
     await _controller.close();
@@ -87,3 +92,5 @@ class SecondaryAddressFinderMock extends Mock
 
 class SecondaryConnectionBridgeMock extends Mock
     implements SecondaryConnectionBridge {}
+
+class SocketCreatorMock extends Mock implements SocketCreator {}

--- a/packages/at_secondary_proxy/test/secondary_connection_bridge_test.dart
+++ b/packages/at_secondary_proxy/test/secondary_connection_bridge_test.dart
@@ -32,7 +32,7 @@ void main() {
       writes = <String>[];
 
       // define how clientSocket responds to .write
-      when(() => clientSocket.write(any)).thenAnswer((invocation) {
+      when(() => clientSocket.write(any())).thenAnswer((invocation) {
         // capture what is written to the socket
         writes.add(invocation.positionalArguments[0] as String);
         return;

--- a/packages/at_secondary_proxy/test/secondary_connection_bridge_test.dart
+++ b/packages/at_secondary_proxy/test/secondary_connection_bridge_test.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:mockito/mockito.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import 'package:at_secondary_proxy/src/secondary_connection_bridge.dart';
@@ -24,12 +26,13 @@ void main() {
     setUp(() {
       // create Mocks
       clientSocket = SecureSocketMock();
-      clientSocket.setDoneFuture(Future<void>.value()); // simulate a socket that is open and not closed
+      clientSocket.setDoneFuture(Future<
+          void>.value()); // simulate a socket that is open and not closed
       addressFinder = SecondaryAddressFinderMock();
       writes = <String>[];
 
       // define how clientSocket responds to .write
-      when(clientSocket.write(any)).thenAnswer((invocation) {
+      when(() => clientSocket.write(any)).thenAnswer((invocation) {
         // capture what is written to the socket
         writes.add(invocation.positionalArguments[0] as String);
         return;
@@ -39,7 +42,8 @@ void main() {
       SecondaryConnectionBridge(dummyProxyUrl, clientSocket, addressFinder);
     });
 
-    test('SecondaryConnectionBridge sends "@" prompt upon construction', () async {
+    test('SecondaryConnectionBridge sends "@" prompt upon construction',
+        () async {
       // in this test,
       // we expect it to send back "@" prompt when the connection is established
       // this indicates that the proxy server created a bridge for us to that atServer
@@ -48,13 +52,16 @@ void main() {
       expect(writes, contains('@'));
     });
 
-    test('SecondaryConnectionBridge is in `opening` state and rejects non-`from:` commands', () async {
+    test(
+        'SecondaryConnectionBridge is in `opening` state and rejects non-`from:` commands',
+        () async {
       // in this test,
       // we send a non-valid command to the proxy server
       // we expect it to return the address of the proxy server back to us (Which is the same address we connected with anyways)
 
       // simulate sending an invalid command
-      final Uint8List invalidCommand = Uint8List.fromList('invalid_command\n'.codeUnits);
+      final Uint8List invalidCommand =
+          Uint8List.fromList('invalid_command\n'.codeUnits);
       clientSocket.controller.add(invalidCommand);
 
       // give some time for the async processing to complete
@@ -67,6 +74,66 @@ void main() {
 
     tearDown(() async {
       await clientSocket.closeController();
+    });
+  });
+
+  group('SecondaryConnectionBridge race conditions', () {
+    // a mock SecureSocket to simulate client connection
+    late SecureSocketMock clientSocket;
+
+    late SecureSocketMock mockSecondarySocket;
+
+    List<String> reads = <String>[];
+
+    // a mock SecondaryAddressFinder, we don't care about its behavior in these tests
+    late SecondaryAddressFinderMock addressFinder;
+
+    // a mock SocketCreator to simulate creating secondary connections
+    late SocketCreatorMock socketCreator;
+
+    setUp(() {
+      clientSocket = SecureSocketMock();
+      clientSocket.setDoneFuture(Future<
+          void>.value()); // simulate a socket that is open and not closed
+      addressFinder = SecondaryAddressFinderMock();
+      socketCreator = SocketCreatorMock();
+      mockSecondarySocket = SecureSocketMock();
+    });
+    test('SecondaryConnectionBridge does not fail when writing concurrently',
+        () async {
+      when(() => mockSecondarySocket.add(any())).thenAnswer((invocation) {
+        // capture what is written to the socket
+        mockSecondarySocket.controller
+            .add(invocation.positionalArguments[0] as Uint8List);
+        reads.add(utf8.decode(invocation.positionalArguments[0] as Uint8List));
+        return;
+      });
+
+      when(() => socketCreator.create(any(), any()))
+          .thenAnswer((_) async => mockSecondarySocket);
+
+      when(() => addressFinder.findSecondary(any()))
+          .thenAnswer((_) async => SecondaryAddress('secondary.example', 64));
+      // create the SecondaryConnectionBridge
+      SecondaryConnectionBridge(
+          dummyProxyUrl, clientSocket, addressFinder,
+          socketCreator: socketCreator);
+      // simulate sending a valid from: command
+      final Uint8List validCommand =
+          Uint8List.fromList('from:@alice\n'.codeUnits);
+      clientSocket.controller.add(validCommand);
+
+      // give some time for the async processing to complete
+      await Future.delayed(Duration(milliseconds: 500));
+
+      // Simulate multiple writes happening concurrently
+      clientSocket.controller.add(Uint8List.fromList("Hello".codeUnits));
+      clientSocket.controller.add(Uint8List.fromList("World".codeUnits));
+      clientSocket.controller.add(Uint8List.fromList("!\n".codeUnits));
+
+      // give some time for the async processing to complete
+      await Future.delayed(Duration(milliseconds: 100));
+      expect(reads, containsAll(['Hello', 'World', '!\n']));
     });
   });
 }


### PR DESCRIPTION
**- What I did**
#70, removed all flush calls except for _writeStringAndClose to ensure we flush the last message.

flush being called in our socket.listen() was causing flush to fail due to writing/flushing concurrently.

**- How I did it**
 - Removed flush from onData methods
 - Introduced a test for concurrent flushing
 
**- How to verify it**
 - Manually tested the secondary proxy with root.atsign.org using at_repl and noports
 - Unit test describing the bug we ran into with concurrent flushing.
    - Test fails when using flush(), test passes when removing it.
 
**- Description for the changelog**
fix: removed flush in listen to prevent breaking during concurrent calls
