### PR TITLE
docs: Fix SLSA verification URI

### DIFF
--- a/packages/at_secondary_proxy/README.md
+++ b/packages/at_secondary_proxy/README.md
@@ -90,7 +90,7 @@ IMAGE="atsigncompany/at_proxyserver"
 SHA=$(docker buildx imagetools inspect ${IMAGE}:${TAG} \
   --format "{{json .Manifest}}" | jq -r .digest)
 slsa-verifier verify-image ${IMAGE}@${SHA} --source-uri \
-  github.com/atsign-foundation/at_server
+  github.com/atsign-foundation/at_services
 ```
 
 ## Docker image signing


### PR DESCRIPTION
Wrong URI in SLSA verification due to pasted text not being correctly modified

**- What I did**

Corrected URI to reference this repo

**- How to verify it**

I've run the corrected text against the latest image and it verifies :)

**- Description for the changelog**

docs: Fix SLSA verification URI
