### PR TITLE
fix: do not request clients to present an SSL cert

### DIFF
--- a/packages/at_secondary_proxy/CHANGELOG.md
+++ b/packages/at_secondary_proxy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # at_secondary_proxy change log
 
+## 2.0.1
+
+- fix: do not request clients to present an SSL cert as it is not required
+
 ## 2.0.0
 
 - Added direct proxy resolution to atSign lookups and forward to Secondary

--- a/packages/at_secondary_proxy/lib/src/secondary_proxy_server.dart
+++ b/packages/at_secondary_proxy/lib/src/secondary_proxy_server.dart
@@ -31,8 +31,7 @@ class SecondaryProxyServer {
     secCon.usePrivateKey(_privateKeyLocation);
     secCon.setTrustedCertificates(_trustedCertificateLocation);
 
-    SecureServerSocket.bind(InternetAddress.anyIPv4, bindPort, secCon,
-            requestClientCertificate: true)
+    SecureServerSocket.bind(InternetAddress.anyIPv4, bindPort, secCon)
         .then((SecureServerSocket secureServerSocket) {
       logger.info('Secure Socket listening on port $bindPort');
       _secureServerSocket = secureServerSocket;
@@ -43,7 +42,7 @@ class SecondaryProxyServer {
 
   void stopServing() {}
 
-  void _listen(secureServerSocket) {
+  void _listen(SecureServerSocket secureServerSocket) {
     secureServerSocket.listen(((clientSocket) {
       if (!_running) {
         logger.info('Server cannot accept connections now.');

--- a/packages/at_secondary_proxy/pubspec.yaml
+++ b/packages/at_secondary_proxy/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary_proxy
 description: A reverse proxy through which clients can connect to secondary servers
-version: 1.0.1
+version: 2.0.1
 
 environment:
   sdk: '>=3.0.0'


### PR DESCRIPTION
**- What I did**
- Remove the wholly unnecessary `requestClientCertificate:true` from the bind in `startServing` ... looks like recent dart increment has changed behaviour where previously this didn't cause an exception but now it does
- fixes #149 

**- How I did it**
See commits

**- How to verify it**
Tests pass
