### PR TITLE
fix: use different SecurityContexts for serverSocket vs client sockets

### DIFF
--- a/packages/at_secondary_proxy/CHANGELOG.md
+++ b/packages/at_secondary_proxy/CHANGELOG.md
@@ -1,5 +1,10 @@
 # at_secondary_proxy change log
 
+## 2.0.2
+
+- fix: use different SecurityContexts for (1) the bound server socket
+  (2) creation of new client sockets to the atServers
+
 ## 2.0.1
 
 - fix: do not request clients to present an SSL cert as it is not required

--- a/packages/at_secondary_proxy/lib/at_secondary_proxy.dart
+++ b/packages/at_secondary_proxy/lib/at_secondary_proxy.dart
@@ -1,3 +1,1 @@
-library at_secondary_proxy;
-
 export 'src/secondary_proxy_server.dart';

--- a/packages/at_secondary_proxy/lib/src/secondary_connection_bridge.dart
+++ b/packages/at_secondary_proxy/lib/src/secondary_connection_bridge.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_utils/at_utils.dart';
 import 'package:at_lookup/at_lookup.dart';
@@ -23,10 +24,12 @@ class SecondaryConnectionBridge {
 
   final SecondaryAddressFinder _secondaryAddressFinder;
 
+  final SecurityContext clientContext;
+
   late String _atSign;
 
-  SecondaryConnectionBridge(
-      this.proxyUrl, this._clientSocket, this._secondaryAddressFinder,
+  SecondaryConnectionBridge(this.proxyUrl, this._clientSocket,
+      this._secondaryAddressFinder, this.clientContext,
       {SocketCreator? socketCreator})
       : _socketCreator = socketCreator ?? DefaultSocketCreator() {
     _clientSocket.listen(_clientOnData,
@@ -39,7 +42,7 @@ class SecondaryConnectionBridge {
 
   final _buffer = ByteBuffer(terminatingChar: '\n', capacity: 511);
 
-  Future<void> _clientOnData(data) async {
+  Future<void> _clientOnData(Uint8List data) async {
     switch (_state) {
       case BridgeState.opening:
         // Expecting to receive from:<atSign>\n
@@ -81,7 +84,7 @@ class SecondaryConnectionBridge {
           try {
             _logger.info("Connecting to $secondaryAddress");
             _secondarySocket = await _socketCreator.create(
-                secondaryAddress.host, secondaryAddress.port);
+                secondaryAddress.host, secondaryAddress.port, clientContext);
           } catch (e) {
             await _writeStringAndClose(e.toString());
             return;
@@ -117,7 +120,7 @@ class SecondaryConnectionBridge {
     }
   }
 
-  Future<void> _secondaryOnData(data) async {
+  Future<void> _secondaryOnData(Uint8List data) async {
     switch (_state) {
       case BridgeState.opening:
         // Should not be possible
@@ -152,16 +155,16 @@ class SecondaryConnectionBridge {
     }
   }
 
-  Future<void> _clientOnError(error) async {
-    _logger.severe('_clientOnError(${error.toString()})');
+  Future<void> _clientOnError(Object? error) async {
+    _logger.severe('_clientOnError(${error?.toString()})');
     if (_state == BridgeState.open) {
       // nothing to do for any other state
       _destroySecondaryThenClient();
     }
   }
 
-  Future<void> _secondaryOnError(error) async {
-    _logger.severe('_secondaryOnError(${error.toString()})');
+  Future<void> _secondaryOnError(Object? error) async {
+    _logger.severe('_secondaryOnError(${error?.toString()})');
     if (_state == BridgeState.open) {
       // nothing to do for any other state
       _destroyClientThenSecondary();
@@ -219,11 +222,20 @@ class SecondaryConnectionBridge {
 }
 
 abstract interface class SocketCreator {
-  Future<SecureSocket> create(String host, int port);
+  Future<SecureSocket> create(
+    String host,
+    int port,
+    SecurityContext clientContext,
+  );
 }
+
 class DefaultSocketCreator implements SocketCreator {
   @override
-  Future<SecureSocket> create(String host, int port) {
-    return SecureSocket.connect(host, port);
+  Future<SecureSocket> create(
+    String host,
+    int port,
+    SecurityContext clientContext,
+  ) {
+    return SecureSocket.connect(host, port, context: clientContext);
   }
 }

--- a/packages/at_secondary_proxy/lib/src/secondary_proxy_server.dart
+++ b/packages/at_secondary_proxy/lib/src/secondary_proxy_server.dart
@@ -19,38 +19,49 @@ class SecondaryProxyServer {
   late SecureServerSocket _secureServerSocket;
 
   bool _running = false;
+
   bool get running => _running;
 
   SecondaryProxyServer(this.proxyUrl, this.proxyPort, this.bindPort,
       this.secondaryAddressFinder);
 
   void startServing() {
-    var secCon = SecurityContext.defaultContext;
+    SecurityContext serverContext = SecurityContext(withTrustedRoots: true);
 
-    secCon.useCertificateChain(_certificateChainLocation);
-    secCon.usePrivateKey(_privateKeyLocation);
-    secCon.setTrustedCertificates(_trustedCertificateLocation);
+    serverContext.useCertificateChain(_certificateChainLocation);
+    serverContext.usePrivateKey(_privateKeyLocation);
+    serverContext.setTrustedCertificates(_trustedCertificateLocation);
 
-    SecureServerSocket.bind(InternetAddress.anyIPv4, bindPort, secCon)
+    SecureServerSocket.bind(InternetAddress.anyIPv4, bindPort, serverContext)
         .then((SecureServerSocket secureServerSocket) {
       logger.info('Secure Socket listening on port $bindPort');
       _secureServerSocket = secureServerSocket;
-      _listen(_secureServerSocket);
+      SecurityContext clientContext = SecurityContext(withTrustedRoots: true);
+      _listen(_secureServerSocket, clientContext);
       _running = true;
     });
   }
 
   void stopServing() {}
 
-  void _listen(SecureServerSocket secureServerSocket) {
+  void _listen(
+    SecureServerSocket secureServerSocket,
+    SecurityContext clientContext,
+  ) {
     secureServerSocket.listen(((clientSocket) {
       if (!_running) {
         logger.info('Server cannot accept connections now.');
         return;
       }
-      logger.info('New client socket connection with peerCertificate : ${clientSocket.peerCertificate}');
+      logger.info(
+          'New client socket connection with peerCertificate : ${clientSocket.peerCertificate}');
 
-      SecondaryConnectionBridge(proxyUrl, clientSocket, secondaryAddressFinder);
+      SecondaryConnectionBridge(
+        proxyUrl,
+        clientSocket,
+        secondaryAddressFinder,
+        clientContext,
+      );
     }), onError: (error) {
       logger.warning('listen.onError : $error');
     });

--- a/packages/at_secondary_proxy/pubspec.yaml
+++ b/packages/at_secondary_proxy/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary_proxy
 description: A reverse proxy through which clients can connect to secondary servers
-version: 2.0.1
+version: 2.0.2
 
 environment:
   sdk: '>=3.0.0'

--- a/packages/at_secondary_proxy/test/secondary_connection_bridge_test.dart
+++ b/packages/at_secondary_proxy/test/secondary_connection_bridge_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:at_lookup/at_lookup.dart';
@@ -38,8 +39,17 @@ void main() {
         return;
       });
 
+      registerFallbackValue(
+        SecurityContext(withTrustedRoots: true),
+      );
+
       // create the SecondaryConnectionBridge
-      SecondaryConnectionBridge(dummyProxyUrl, clientSocket, addressFinder);
+      SecondaryConnectionBridge(
+        dummyProxyUrl,
+        clientSocket,
+        addressFinder,
+        SecurityContext(withTrustedRoots: true),
+      );
     });
 
     test('SecondaryConnectionBridge sends "@" prompt upon construction',
@@ -109,14 +119,14 @@ void main() {
         return;
       });
 
-      when(() => socketCreator.create(any(), any()))
+      when(() => socketCreator.create(any(), any(), any()))
           .thenAnswer((_) async => mockSecondarySocket);
 
       when(() => addressFinder.findSecondary(any()))
           .thenAnswer((_) async => SecondaryAddress('secondary.example', 64));
       // create the SecondaryConnectionBridge
-      SecondaryConnectionBridge(
-          dummyProxyUrl, clientSocket, addressFinder,
+      SecondaryConnectionBridge(dummyProxyUrl, clientSocket, addressFinder,
+          SecurityContext(withTrustedRoots: true),
           socketCreator: socketCreator);
       // simulate sending a valid from: command
       final Uint8List validCommand =


### PR DESCRIPTION
**- What I did**
- fixes #151 
- fix: use different SecurityContexts for (1) the bound server socket (2) creation of new client sockets to the atServers
- chore: lint

**- How I did it**

**- How to verify it**
- Tests pass
- Once merged and new docker image published, will run at_client_sdk e2e tests to verify
