### PR TITLE
feat(at_secondary_proxy): bridge WebSocket connections to atServers

### DIFF
--- a/packages/at_secondary_proxy/CHANGELOG.md
+++ b/packages/at_secondary_proxy/CHANGELOG.md
@@ -1,5 +1,14 @@
 # at_secondary_proxy change log
 
+## 2.2.0
+
+- feat: bridge inbound WebSocket connections (path `/ws`, ALPN
+  `http/1.1`) to upstream atServers. The bridge mirrors the existing
+  TCP `SecondaryConnectionBridge`: it writes `@` to the client on
+  connect, waits for `from:<atSign>\n`, looks up the upstream
+  atServer, opens a WebSocket to it, and forwards frames
+  bidirectionally preserving text/binary frame type.
+
 ## 2.1.0
 
 - feat: enable proxy service to handle http GET requests

--- a/packages/at_secondary_proxy/README.md
+++ b/packages/at_secondary_proxy/README.md
@@ -6,11 +6,24 @@
 
 ## at_secondary_proxy
 
-**at_secondary_proxy** acts as a TCP reverse proxy for connections from
+**at_secondary_proxy** acts as a reverse proxy for connections from
 clients to secondary servers, where the clients are limited in the ports
 they can connect to - for example if they are behind a firewall which limits
 the ports that outgoing connections can connect to using an allow-list or
 block-list or both.
+
+The proxy uses TLS ALPN to dispatch each inbound connection:
+
+* `atProtocol/1.0` or null — bridged to the upstream atServer as a raw
+  `SecureSocket`. The proxy waits for a `from:<atSign>\n` from the
+  client, looks up that atSign's atServer, and forwards bytes
+  bidirectionally.
+* `http/1.1` — handled either as an HTTP GET (e.g. `/@<atSign>` or
+  `/@<atSign>/<key>`) or, when the request path is `/ws`, upgraded
+  to a WebSocket and bridged to the upstream atServer's own `/ws`
+  endpoint. The WebSocket bridge uses the same `from:`-based
+  discovery handshake as the TCP path, with WebSocket frames in
+  place of raw bytes.
 
 ### Usage
 

--- a/packages/at_secondary_proxy/lib/src/secondary_bridge_base.dart
+++ b/packages/at_secondary_proxy/lib/src/secondary_bridge_base.dart
@@ -1,0 +1,237 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' show SecurityContext, WebSocketStatus;
+
+import 'package:at_commons/at_commons.dart' hide StringBuffer;
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_utils/at_utils.dart';
+
+enum BridgeState { opening, open, closing, closed }
+
+/// Shared state machine for the proxy's two bridge implementations
+/// ([SecondaryConnectionBridge] for raw `SecureSocket`s and
+/// [SecondaryWebSocketBridge] for `WebSocket`s). Owns:
+/// * the [BridgeState] lifecycle,
+/// * the opening-state buffer accumulation, `from:` parsing, atSign lookup,
+///   upstream-connect, and bootstrap-forward,
+/// * the symmetric done/error → teardown orchestration.
+///
+/// Transport-specific operations (writing the `@` prompt, forwarding frames
+/// preserving frame type, destroying sockets, etc.) are abstract and live
+/// on the subclass.
+abstract class SecondaryBridgeBase {
+  final String proxyUrl;
+  final SecondaryAddressFinder _secondaryAddressFinder;
+  final SecurityContext clientContext;
+
+  BridgeState _state = BridgeState.opening;
+  BridgeState get state => _state;
+
+  late String _atSign;
+  String get atSign => _atSign;
+
+  AtSignLogger _logger;
+  AtSignLogger get logger => _logger;
+
+  final ByteBuffer _buffer = ByteBuffer(terminatingChar: '\n', capacity: 511);
+
+  SecondaryBridgeBase(
+    this.proxyUrl,
+    this._secondaryAddressFinder,
+    this.clientContext, {
+    required AtSignLogger initialLogger,
+  }) : _logger = initialLogger;
+
+  /// Subclasses call this from their inbound listener for each frame /
+  /// chunk from the client. [bytes] is the byte view used for buffer
+  /// accumulation (text WebSocket frames pre-encoded as UTF-8). [original]
+  /// is what gets forwarded as-is in [BridgeState.open] so frame type
+  /// (text vs binary) survives.
+  Future<void> handleClientData(List<int> bytes, dynamic original) async {
+    switch (_state) {
+      case BridgeState.opening:
+        if (_buffer.isOverFlow(bytes)) {
+          await writeErrorAndClose('Too much');
+          return;
+        }
+        _buffer.append(bytes);
+        if (_buffer.isEnd()) {
+          await _processFromCommand();
+        }
+        break;
+      case BridgeState.open:
+        forwardToSecondaryOpen(original);
+        break;
+      case BridgeState.closing:
+      case BridgeState.closed:
+        break;
+    }
+  }
+
+  Future<void> _processFromCommand() async {
+    var command = utf8.decode(_buffer.getData()).trim();
+    if (!command.startsWith('from:')) {
+      _logger.info('First command was not "from:" — sending proxyUrl');
+      await writeErrorAndClose(proxyUrl);
+      return;
+    }
+
+    _logger.info('Got "from" command: $command');
+    _atSign = command.split(':')[1];
+    _logger = AtSignLogger('$runtimeType $_atSign');
+
+    late SecondaryAddress secondaryAddress;
+    try {
+      _logger.info('Looking up secondary for $_atSign');
+      secondaryAddress = await _secondaryAddressFinder.findSecondary(_atSign);
+    } catch (e) {
+      await writeErrorAndClose(e.toString());
+      return;
+    }
+
+    try {
+      _logger.info('Connecting to $secondaryAddress');
+      await connectSecondary(secondaryAddress.host, secondaryAddress.port);
+    } catch (e) {
+      await writeErrorAndClose(e.toString(),
+          closeCode: WebSocketStatus.internalServerError);
+      return;
+    }
+
+    try {
+      _logger
+          .info('Forwarding ${_buffer.length()} buffered bytes to secondary');
+      forwardBufferedToSecondary(_buffer.getData(), command);
+      _logger.info('Bridge is open');
+      _state = BridgeState.open;
+    } catch (e) {
+      await writeErrorAndClose(e.toString(),
+          closeCode: WebSocketStatus.internalServerError);
+      destroySecondary();
+      return;
+    }
+  }
+
+  Future<void> handleSecondaryData(dynamic data) async {
+    switch (_state) {
+      case BridgeState.opening:
+        _logger
+            .severe('handleSecondaryData called while BridgeState is $_state');
+        break;
+      case BridgeState.open:
+        forwardToClientOpen(data);
+        break;
+      case BridgeState.closing:
+      case BridgeState.closed:
+        break;
+    }
+  }
+
+  Future<void> handleClientDone() async {
+    _logger.info('handleClientDone()');
+    if (_state == BridgeState.open) {
+      _destroySecondaryThenClient();
+    }
+  }
+
+  Future<void> handleSecondaryDone() async {
+    _logger.info('handleSecondaryDone()');
+    if (_state == BridgeState.open) {
+      _destroyClientThenSecondary();
+    }
+  }
+
+  Future<void> handleClientError(Object? error) async {
+    _logger.severe('handleClientError(${error?.toString()})');
+    if (_state == BridgeState.open) {
+      _destroySecondaryThenClient();
+    }
+  }
+
+  Future<void> handleSecondaryError(Object? error) async {
+    _logger.severe('handleSecondaryError(${error?.toString()})');
+    if (_state == BridgeState.open) {
+      _destroyClientThenSecondary();
+    }
+  }
+
+  /// Sends [msg] to the client (transport-specific shape) and then closes
+  /// the inbound side. [closeCode] is honoured by transports that carry
+  /// close codes (WebSocket); transports that don't (raw socket) ignore it.
+  Future<void> writeErrorAndClose(String msg,
+      {int closeCode = WebSocketStatus.policyViolation}) async {
+    _state = BridgeState.closing;
+    _logger.info('writeErrorAndClose : $msg');
+
+    try {
+      await writeErrorToClient(msg);
+    } catch (_) {
+      // ignore — client may already be gone
+    }
+
+    try {
+      await closeClient(closeCode: closeCode, reason: msg);
+    } catch (_) {
+      // ignore
+    }
+
+    _state = BridgeState.closed;
+  }
+
+  void _destroySecondaryThenClient() {
+    _logger.info('_destroySecondaryThenClient()');
+    _state = BridgeState.closing;
+    destroySecondary();
+    destroyClient();
+    _state = BridgeState.closed;
+  }
+
+  void _destroyClientThenSecondary() {
+    _logger.info('_destroyClientThenSecondary()');
+    _state = BridgeState.closing;
+    destroyClient();
+    destroySecondary();
+    _state = BridgeState.closed;
+  }
+
+  // -------------------------------------------------------------------------
+  // Transport-specific operations supplied by subclasses.
+  // -------------------------------------------------------------------------
+
+  /// Send the initial `@` prompt to the client.
+  void sendPrompt();
+
+  /// Send an error message to the client (newline-terminated for raw socket
+  /// callers; a single text frame for WebSocket callers).
+  Future<void> writeErrorToClient(String msg);
+
+  /// Close the inbound side. [closeCode]/[reason] are advisory — transports
+  /// that don't carry them may ignore them.
+  Future<void> closeClient({int? closeCode, String? reason});
+
+  /// Open the outbound connection to the upstream atServer at [host]/[port]
+  /// and wire its inbound listener to [handleSecondaryData] /
+  /// [handleSecondaryDone] / [handleSecondaryError].
+  Future<void> connectSecondary(String host, int port);
+
+  /// Forward the buffered initial bytes ([bufferedBytes]) plus the parsed
+  /// command ([parsedCommand], without trailing newline) to the upstream.
+  /// Subclasses choose whether to send the raw buffer or the rebuilt
+  /// `'$parsedCommand\n'` — both are valid for atProtocol.
+  void forwardBufferedToSecondary(
+      List<int> bufferedBytes, String parsedCommand);
+
+  /// Forward a frame received from the client to the upstream (open state),
+  /// preserving frame type for transports that distinguish.
+  void forwardToSecondaryOpen(dynamic data);
+
+  /// Forward a frame received from the upstream to the client (open state),
+  /// preserving frame type for transports that distinguish.
+  void forwardToClientOpen(dynamic data);
+
+  /// Tear down the inbound side immediately (no graceful close).
+  void destroyClient();
+
+  /// Tear down the outbound side immediately (no graceful close).
+  void destroySecondary();
+}

--- a/packages/at_secondary_proxy/lib/src/secondary_connection_bridge.dart
+++ b/packages/at_secondary_proxy/lib/src/secondary_connection_bridge.dart
@@ -1,223 +1,105 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
-import 'package:at_commons/at_commons.dart';
-import 'package:at_utils/at_utils.dart';
+
 import 'package:at_lookup/at_lookup.dart';
+import 'package:at_utils/at_utils.dart';
 
-enum BridgeState { opening, open, closing, closed }
+import 'secondary_bridge_base.dart';
 
-class SecondaryConnectionBridge {
+export 'secondary_bridge_base.dart' show BridgeState;
+
+/// Bridges an inbound atProtocol [SecureSocket] from an atClient to an
+/// outbound [SecureSocket] on the upstream atServer. State machine and
+/// orchestration live in [SecondaryBridgeBase]; this class supplies the
+/// `SecureSocket`-specific transport ops.
+class SecondaryConnectionBridge extends SecondaryBridgeBase {
   final SecureSocket _clientSocket;
   late SecureSocket _secondarySocket;
-  final String proxyUrl;
-
-  static final AtSignLogger _initialLogger =
-      AtSignLogger('SecondaryConnectionBridge');
-
-  AtSignLogger _logger = _initialLogger;
-
-  BridgeState _state = BridgeState.opening;
 
   final SocketCreator _socketCreator;
 
-  final SecondaryAddressFinder _secondaryAddressFinder;
+  SecondaryConnectionBridge(
+    String proxyUrl,
+    this._clientSocket,
+    SecondaryAddressFinder secondaryAddressFinder,
+    SecurityContext clientContext, {
+    SocketCreator? socketCreator,
+  })  : _socketCreator = socketCreator ?? DefaultSocketCreator(),
+        super(
+          proxyUrl,
+          secondaryAddressFinder,
+          clientContext,
+          initialLogger: AtSignLogger('SecondaryConnectionBridge'),
+        ) {
+    _clientSocket.listen(
+      (Uint8List data) => handleClientData(data, data),
+      onDone: handleClientDone,
+      onError: handleClientError,
+    );
+    _clientSocket.done.onError((error, _) => handleClientError(error));
 
-  final SecurityContext clientContext;
-
-  late String _atSign;
-
-  SecondaryConnectionBridge(this.proxyUrl, this._clientSocket,
-      this._secondaryAddressFinder, this.clientContext,
-      {SocketCreator? socketCreator})
-      : _socketCreator = socketCreator ?? DefaultSocketCreator() {
-    _clientSocket.listen(_clientOnData,
-        onDone: _clientOnDone, onError: _clientOnError);
-    _clientSocket.done.onError((error, stackTrace) => (_clientOnError(error)));
-
-    _logger.info("Sending @ prompt; started listening on new client socket");
-    _clientSocket.write("@");
+    logger.info('Sending @ prompt; started listening on new client socket');
+    sendPrompt();
   }
 
-  final _buffer = ByteBuffer(terminatingChar: '\n', capacity: 511);
+  @override
+  void sendPrompt() => _clientSocket.write('@');
 
-  Future<void> _clientOnData(Uint8List data) async {
-    switch (_state) {
-      case BridgeState.opening:
-        // Expecting to receive from:<atSign>\n
-        if (_buffer.isOverFlow(data)) {
-          await _writeStringAndClose('Too much');
-          return;
-        }
-
-        _buffer.append(data);
-
-        if (_buffer.isEnd()) {
-          // We've received the '\n'
-          var command = utf8.decode(_buffer.getData());
-          command = command.trim();
-          // If we get to \n and the command doesn't start with "from:" then log something and close this bridge
-          if (!command.startsWith("from:")) {
-            _logger.info('Looking up secondary for @$command');
-            await _writeStringAndClose(proxyUrl);
-            return;
-          }
-
-          // We've got a 'from:' command - let's get the atSign
-          _logger.info('Got "from" command: $command');
-          _atSign = command.split(":")[1];
-          _logger = AtSignLogger('SecondaryConnectionBridge $_atSign');
-
-          // We've got the @-sign - let's look up the address
-          late SecondaryAddress secondaryAddress;
-          try {
-            _logger.info("Looking up secondary for $_atSign");
-            secondaryAddress =
-                await _secondaryAddressFinder.findSecondary(_atSign);
-          } catch (e) {
-            await _writeStringAndClose(e.toString());
-            return;
-          }
-
-          // connect to the secondary
-          try {
-            _logger.info("Connecting to $secondaryAddress");
-            _secondarySocket = await _socketCreator.create(
-                secondaryAddress.host, secondaryAddress.port, clientContext);
-          } catch (e) {
-            await _writeStringAndClose(e.toString());
-            return;
-          }
-          _logger.info("Setting up secondary socket listen");
-          _secondarySocket.listen(_secondaryOnData,
-              onDone: _secondaryOnDone, onError: _secondaryOnError);
-          unawaited(_secondarySocket.done
-              .onError((error, stackTrace) => (_clientOnError(error))));
-
-          try {
-            _logger.info("Writing command $command plus \\n");
-            _secondarySocket.write('$command\n');
-
-            _logger.info("Bridge is open");
-            _state = BridgeState.open;
-          } catch (e) {
-            await _writeStringAndClose(e.toString());
-            _destroySecondarySocket();
-            return;
-          }
-        }
-        break;
-      case BridgeState.open:
-        _secondarySocket.add(data);
-        break;
-      case BridgeState.closing:
-        // Nothing to do here
-        break;
-      case BridgeState.closed:
-        // Nothing to do here
-        break;
-    }
+  @override
+  Future<void> writeErrorToClient(String msg) async {
+    _clientSocket.write('$msg\n');
+    await _clientSocket.flush();
   }
 
-  Future<void> _secondaryOnData(Uint8List data) async {
-    switch (_state) {
-      case BridgeState.opening:
-        // Should not be possible
-        _logger.severe(
-            "_serverMessageHandler called while BridgeState is $_state");
-        break;
-      case BridgeState.open:
-        _clientSocket.add(data);
-        break;
-      case BridgeState.closing:
-        // Nothing to do here
-        break;
-      case BridgeState.closed:
-        // Nothing to do here
-        break;
-    }
+  @override
+  Future<void> closeClient({int? closeCode, String? reason}) async {
+    destroyClient();
   }
 
-  Future<void> _clientOnDone() async {
-    _logger.info('_clientOnDone()');
-    if (_state == BridgeState.open) {
-      // nothing to do for any other state
-      _destroySecondaryThenClient();
-    }
+  @override
+  Future<void> connectSecondary(String host, int port) async {
+    _secondarySocket = await _socketCreator.create(host, port, clientContext);
+    logger.info('Setting up secondary socket listen');
+    _secondarySocket.listen(
+      (Uint8List data) => handleSecondaryData(data),
+      onDone: handleSecondaryDone,
+      onError: handleSecondaryError,
+    );
+    unawaited(
+        _secondarySocket.done.onError((error, _) => handleClientError(error)));
   }
 
-  Future<void> _secondaryOnDone() async {
-    _logger.info('_secondaryOnDone()');
-    if (_state == BridgeState.open) {
-      // nothing to do for any other state
-      _destroyClientThenSecondary();
-    }
+  @override
+  void forwardBufferedToSecondary(
+      List<int> bufferedBytes, String parsedCommand) {
+    // Preserves the historical behaviour of writing the trim-normalised
+    // command back, rather than the raw buffered bytes.
+    _secondarySocket.write('$parsedCommand\n');
   }
 
-  Future<void> _clientOnError(Object? error) async {
-    _logger.severe('_clientOnError(${error?.toString()})');
-    if (_state == BridgeState.open) {
-      // nothing to do for any other state
-      _destroySecondaryThenClient();
-    }
+  @override
+  void forwardToSecondaryOpen(dynamic data) {
+    _secondarySocket.add(data as List<int>);
   }
 
-  Future<void> _secondaryOnError(Object? error) async {
-    _logger.severe('_secondaryOnError(${error?.toString()})');
-    if (_state == BridgeState.open) {
-      // nothing to do for any other state
-      _destroyClientThenSecondary();
-    }
+  @override
+  void forwardToClientOpen(dynamic data) {
+    _clientSocket.add(data as List<int>);
   }
 
-  Future<void> _writeStringAndClose(String msg) async {
-    _state = BridgeState.closing;
-
-    _logger.info("_writeStringAndClose : $msg");
-
-    try {
-      _clientSocket.write('$msg\n');
-      await (_clientSocket.flush());
-    }
-    // ignore: empty_catches
-    catch (ignore) {}
-
-    _destroyClientSocket();
-
-    _state = BridgeState.closed;
-  }
-
-  void _destroySecondaryThenClient() {
-    _logger.info("_destroySecondaryThenClient()");
-    _state = BridgeState.closing;
-    _destroySecondarySocket();
-    _destroyClientSocket();
-    _state = BridgeState.closed;
-  }
-
-  void _destroyClientThenSecondary() {
-    _logger.info("_destroyClientThenSecondary()");
-    _state = BridgeState.closing;
-    _destroyClientSocket();
-    _destroySecondarySocket();
-    _state = BridgeState.closed;
-  }
-
-  void _destroyClientSocket() {
+  @override
+  void destroyClient() {
     try {
       _clientSocket.destroy();
-    }
-    // ignore: empty_catches
-    catch (ignore) {}
+    } catch (_) {}
   }
 
-  void _destroySecondarySocket() {
+  @override
+  void destroySecondary() {
     try {
       _secondarySocket.destroy();
-    }
-    // ignore: empty_catches
-    catch (ignore) {}
+    } catch (_) {}
   }
 }
 

--- a/packages/at_secondary_proxy/lib/src/secondary_proxy_server.dart
+++ b/packages/at_secondary_proxy/lib/src/secondary_proxy_server.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 
 import 'secondary_connection_bridge.dart';
+import 'secondary_websocket_bridge.dart';
 
 class SecondaryProxyServer {
   static final String _certificateChainLocation = 'certs/fullchain.pem';
@@ -18,9 +19,16 @@ class SecondaryProxyServer {
   final int bindPort;
   final String proxyUrl;
   final SecondaryAddressFinder secondaryAddressFinder;
-  final ioClient = IOClient(HttpClient(
-      context: SecurityContext(withTrustedRoots: true)
-        ..setAlpnProtocols(['http/1.1'], false)));
+  final ioClient = IOClient(HttpClient(context: _outboundHttpContext()));
+
+  /// Builds the SecurityContext for outbound connections to upstream
+  /// atServers (trust roots + http/1.1 ALPN). Used by both the HTTP GET
+  /// path and the WebSocket-bridge path so they negotiate the same ALPN.
+  static SecurityContext _outboundHttpContext() =>
+      SecurityContext(withTrustedRoots: true)
+        ..setAlpnProtocols(['http/1.1'], false);
+
+  final SecurityContext outboundWebSocketContext = _outboundHttpContext();
 
   late SecureServerSocket _secureServerSocket;
 
@@ -65,10 +73,17 @@ class SecondaryProxyServer {
     HttpServer httpServer = HttpServer.listenOn(pseudoServerSocket);
     httpServer.listen((HttpRequest req) {
       if (req.uri.path == '/ws') {
-        //   // Upgrade to a WebSocket connection
-        //   logger.info('Upgraded to WebSocket connection');
-        //   WebSocketTransformer.upgrade(req)
-        //       .then((WebSocket ws) => webSocketListener(ws));
+        logger.info('Upgrading inbound to WebSocket');
+        WebSocketTransformer.upgrade(req).then((WebSocket ws) {
+          SecondaryWebSocketBridge(
+            proxyUrl,
+            ws,
+            secondaryAddressFinder,
+            outboundWebSocketContext,
+          );
+        }).catchError((e) {
+          logger.warning('WebSocket upgrade failed: $e');
+        });
       } else {
         handleHttpRequest(req);
       }

--- a/packages/at_secondary_proxy/lib/src/secondary_websocket_bridge.dart
+++ b/packages/at_secondary_proxy/lib/src/secondary_websocket_bridge.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_utils/at_utils.dart';
+
+import 'secondary_bridge_base.dart';
+
+/// Bridges an inbound [WebSocket] from an atClient to an outbound [WebSocket]
+/// on the upstream atServer's `/ws` endpoint. State machine and
+/// orchestration live in [SecondaryBridgeBase]; this class supplies the
+/// `WebSocket`-specific transport ops.
+class SecondaryWebSocketBridge extends SecondaryBridgeBase {
+  final WebSocket _clientWs;
+  late WebSocket _secondaryWs;
+
+  final WebSocketCreator _webSocketCreator;
+
+  SecondaryWebSocketBridge(
+    String proxyUrl,
+    this._clientWs,
+    SecondaryAddressFinder secondaryAddressFinder,
+    SecurityContext clientContext, {
+    WebSocketCreator? webSocketCreator,
+  })  : _webSocketCreator = webSocketCreator ?? DefaultWebSocketCreator(),
+        super(
+          proxyUrl,
+          secondaryAddressFinder,
+          clientContext,
+          initialLogger: AtSignLogger('SecondaryWebSocketBridge'),
+        ) {
+    _clientWs.listen(
+      (dynamic data) {
+        final List<int> bytes =
+            data is String ? utf8.encode(data) : data as List<int>;
+        handleClientData(bytes, data);
+      },
+      onDone: handleClientDone,
+      onError: handleClientError,
+    );
+
+    logger.info('Sending @ prompt; started listening on new client WebSocket');
+    sendPrompt();
+  }
+
+  @override
+  void sendPrompt() => _clientWs.add('@');
+
+  @override
+  Future<void> writeErrorToClient(String msg) async {
+    _clientWs.add('$msg\n');
+  }
+
+  @override
+  Future<void> closeClient({int? closeCode, String? reason}) async {
+    final r = reason == null ? null : _truncateUtf8(reason, 123);
+    await _clientWs.close(closeCode, r);
+  }
+
+  @override
+  Future<void> connectSecondary(String host, int port) async {
+    _secondaryWs = await _webSocketCreator.create(host, port, clientContext);
+    logger.info('Setting up secondary WebSocket listen');
+    _secondaryWs.listen(
+      handleSecondaryData,
+      onDone: handleSecondaryDone,
+      onError: handleSecondaryError,
+    );
+  }
+
+  @override
+  void forwardBufferedToSecondary(
+      List<int> bufferedBytes, String parsedCommand) {
+    // Forward as a single binary frame. The atServer's
+    // InboundMessageListener._messageHandler appends inbound text-frame
+    // bytes (utf8.encode) and binary-frame bytes identically, so binary
+    // is byte-equivalent and avoids re-encoding what we already have as
+    // bytes.
+    _secondaryWs.add(bufferedBytes);
+  }
+
+  @override
+  void forwardToSecondaryOpen(dynamic data) {
+    _secondaryWs.add(data);
+  }
+
+  @override
+  void forwardToClientOpen(dynamic data) {
+    _clientWs.add(data);
+  }
+
+  @override
+  void destroyClient() {
+    try {
+      _clientWs.close();
+    } catch (_) {}
+  }
+
+  @override
+  void destroySecondary() {
+    try {
+      _secondaryWs.close();
+    } catch (_) {}
+  }
+}
+
+/// Truncates [s] so that its UTF-8 encoding fits within [maxBytes], without
+/// splitting a multi-byte character.
+String _truncateUtf8(String s, int maxBytes) {
+  final bytes = utf8.encode(s);
+  if (bytes.length <= maxBytes) return s;
+  var end = maxBytes;
+  while (end > 0 && (bytes[end] & 0xC0) == 0x80) {
+    end--;
+  }
+  return utf8.decode(bytes.sublist(0, end), allowMalformed: true);
+}
+
+abstract interface class WebSocketCreator {
+  Future<WebSocket> create(
+    String host,
+    int port,
+    SecurityContext clientContext,
+  );
+}
+
+class DefaultWebSocketCreator implements WebSocketCreator {
+  @override
+  Future<WebSocket> create(
+    String host,
+    int port,
+    SecurityContext clientContext,
+  ) {
+    final httpClient = HttpClient(context: clientContext);
+    return WebSocket.connect(
+      'wss://$host:$port/ws',
+      customClient: httpClient,
+    );
+  }
+}

--- a/packages/at_secondary_proxy/pubspec.yaml
+++ b/packages/at_secondary_proxy/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_secondary_proxy
 description: A reverse proxy through which clients can connect to secondary servers
-version: 2.1.0
+version: 2.2.0
 
 environment:
   sdk: '>=3.0.0'

--- a/packages/at_secondary_proxy/test/lib/mock/mocks.dart
+++ b/packages/at_secondary_proxy/test/lib/mock/mocks.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_secondary_proxy/src/secondary_connection_bridge.dart';
+import 'package:at_secondary_proxy/src/secondary_websocket_bridge.dart';
 import 'package:mocktail/mocktail.dart';
 
 // Lightweight hand-written mocks so we can control listen/done behavior in unit tests.
@@ -94,3 +95,66 @@ class SecondaryConnectionBridgeMock extends Mock
     implements SecondaryConnectionBridge {}
 
 class SocketCreatorMock extends Mock implements SocketCreator {}
+
+/// Hand-written WebSocket mock paralleling [SecureSocketMock]. Tests drive
+/// inbound frames via [controller.add] and inspect what was sent via [sent]
+/// and [closeArgs].
+class WebSocketMock extends Mock implements WebSocket {
+  final StreamController<dynamic> _controller =
+      StreamController<dynamic>.broadcast();
+  StreamController<dynamic> get controller => _controller;
+
+  /// Frames the bridge wrote to this WebSocket via [add], in order. Each
+  /// entry is the original Dart object passed (`String` or `List<int>`).
+  final List<dynamic> sent = <dynamic>[];
+
+  /// Captures the (code, reason) that the bridge passed to [close].
+  ({int? code, String? reason})? closeArgs;
+
+  final Completer<void> _doneCompleter = Completer<void>();
+
+  @override
+  Future<void> get done => _doneCompleter.future;
+
+  /// Marks the connection as remotely closed (mirrors the underlying
+  /// connection going away). Tests that need to drive an upstream close
+  /// downstream can call this and then [closeController].
+  void completeDone() {
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+  }
+
+  @override
+  StreamSubscription<dynamic> listen(
+    void Function(dynamic data)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    return _controller.stream.listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
+
+  @override
+  void add(dynamic data) {
+    sent.add(data);
+  }
+
+  @override
+  Future<void> close([int? code, String? reason]) async {
+    closeArgs = (code: code, reason: reason);
+    completeDone();
+    await closeController();
+  }
+
+  Future<void> closeController() async {
+    if (!_controller.isClosed) {
+      await _controller.close();
+    }
+  }
+}
+
+class WebSocketCreatorMock extends Mock implements WebSocketCreator {}

--- a/packages/at_secondary_proxy/test/secondary_proxy_server_test.dart
+++ b/packages/at_secondary_proxy/test/secondary_proxy_server_test.dart
@@ -82,6 +82,52 @@ void main() {
       await client.close();
     });
 
+    test('WebSocket on /ws receives @ prompt and triggers findSecondary',
+        () async {
+      final serverSocket = getSecureServerSocket(server);
+      final port = serverSocket.port;
+
+      // HttpClient that accepts the proxy's self-signed cert and negotiates
+      // http/1.1 ALPN (matching what the proxy advertises on its inbound
+      // listener).
+      final httpClient = HttpClient(
+          context: SecurityContext(withTrustedRoots: true)
+            ..setAlpnProtocols(['http/1.1'], false))
+        ..badCertificateCallback = (_, __, ___) => true;
+
+      final ws = await WebSocket.connect(
+        'wss://localhost:$port/ws',
+        customClient: httpClient,
+      );
+
+      final received = <dynamic>[];
+      final firstFrame = Completer<dynamic>();
+      ws.listen(
+        (frame) {
+          received.add(frame);
+          if (!firstFrame.isCompleted) firstFrame.complete(frame);
+        },
+        onError: (_) {},
+        onDone: () {},
+      );
+
+      final prompt =
+          await firstFrame.future.timeout(const Duration(seconds: 2));
+      expect(prompt, '@');
+
+      ws.add('from:@alice\n');
+      // Give the proxy time to parse the command and invoke findSecondary
+      // (which throws in this test, closing the bridge).
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(addressFinder.lookups, contains('@alice'));
+
+      try {
+        await ws.close();
+      } catch (_) {}
+      httpClient.close(force: true);
+    });
+
     test('does not create bridge when running flag is false', () async {
       final serverSocket = getSecureServerSocket(server);
       final port = serverSocket.port;

--- a/packages/at_secondary_proxy/test/secondary_websocket_bridge_test.dart
+++ b/packages/at_secondary_proxy/test/secondary_websocket_bridge_test.dart
@@ -1,0 +1,289 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_secondary_proxy/src/secondary_websocket_bridge.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import 'lib/mock/mocks.dart';
+
+const dummyProxyUrl = 'proxy.example';
+
+WebSocketMock _newClient() {
+  final ws = WebSocketMock();
+  return ws;
+}
+
+SecurityContext _ctx() => SecurityContext(withTrustedRoots: true);
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(SecurityContext(withTrustedRoots: true));
+  });
+
+  group('SecondaryWebSocketBridge opening state', () {
+    late WebSocketMock clientWs;
+    late SecondaryAddressFinderMock addressFinder;
+    late WebSocketCreatorMock creator;
+
+    setUp(() {
+      clientWs = _newClient();
+      addressFinder = SecondaryAddressFinderMock();
+      creator = WebSocketCreatorMock();
+    });
+
+    test('sends "@" prompt as a single text frame on construction', () {
+      SecondaryWebSocketBridge(
+        dummyProxyUrl,
+        clientWs,
+        addressFinder,
+        _ctx(),
+        webSocketCreator: creator,
+      );
+
+      expect(clientWs.sent, equals(<dynamic>['@']));
+      verifyNever(() => addressFinder.findSecondary(any()));
+      verifyNever(() => creator.create(any(), any(), any()));
+    });
+
+    test('valid single-frame from: triggers lookup and forwards bytes',
+        () async {
+      final upstreamWs = WebSocketMock();
+      when(() => addressFinder.findSecondary('@alice'))
+          .thenAnswer((_) async => SecondaryAddress('secondary.example', 64));
+      when(() => creator.create('secondary.example', 64, any()))
+          .thenAnswer((_) async => upstreamWs);
+
+      SecondaryWebSocketBridge(
+        dummyProxyUrl,
+        clientWs,
+        addressFinder,
+        _ctx(),
+        webSocketCreator: creator,
+      );
+
+      clientWs.controller.add('from:@alice\n');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      verify(() => addressFinder.findSecondary('@alice')).called(1);
+      verify(() => creator.create('secondary.example', 64, any())).called(1);
+      // Buffered command bytes were forwarded as one frame.
+      expect(upstreamWs.sent, hasLength(1));
+      expect(utf8.decode(upstreamWs.sent.single as List<int>),
+          equals('from:@alice\n'));
+    });
+
+    test('multi-frame from: is accumulated until newline', () async {
+      final upstreamWs = WebSocketMock();
+      when(() => addressFinder.findSecondary('@alice'))
+          .thenAnswer((_) async => SecondaryAddress('secondary.example', 64));
+      when(() => creator.create(any(), any(), any()))
+          .thenAnswer((_) async => upstreamWs);
+
+      SecondaryWebSocketBridge(
+        dummyProxyUrl,
+        clientWs,
+        addressFinder,
+        _ctx(),
+        webSocketCreator: creator,
+      );
+
+      clientWs.controller.add('from:');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      verifyNever(() => addressFinder.findSecondary(any()));
+
+      clientWs.controller.add('@alice\n');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      verify(() => addressFinder.findSecondary('@alice')).called(1);
+      expect(upstreamWs.sent, hasLength(1));
+      expect(utf8.decode(upstreamWs.sent.single as List<int>),
+          equals('from:@alice\n'));
+    });
+
+    test('mixed text+binary frames in opening accumulate as bytes', () async {
+      final upstreamWs = WebSocketMock();
+      when(() => addressFinder.findSecondary('@alice'))
+          .thenAnswer((_) async => SecondaryAddress('secondary.example', 64));
+      when(() => creator.create(any(), any(), any()))
+          .thenAnswer((_) async => upstreamWs);
+
+      SecondaryWebSocketBridge(
+        dummyProxyUrl,
+        clientWs,
+        addressFinder,
+        _ctx(),
+        webSocketCreator: creator,
+      );
+
+      // text frame: "from:"
+      clientWs.controller.add('from:');
+      // binary frame: "@alice\n"
+      clientWs.controller.add(<int>[0x40, 0x61, 0x6c, 0x69, 0x63, 0x65, 0x0a]);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      verify(() => addressFinder.findSecondary('@alice')).called(1);
+      expect(utf8.decode(upstreamWs.sent.single as List<int>),
+          equals('from:@alice\n'));
+    });
+
+    test('non-from first command sends proxyUrl error frame and closes',
+        () async {
+      SecondaryWebSocketBridge(
+        dummyProxyUrl,
+        clientWs,
+        addressFinder,
+        _ctx(),
+        webSocketCreator: creator,
+      );
+
+      clientWs.controller.add('hello\n');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // sent: ['@', 'proxy.example\n']
+      expect(clientWs.sent, equals(<dynamic>['@', '$dummyProxyUrl\n']));
+      expect(clientWs.closeArgs?.code, WebSocketStatus.policyViolation);
+      verifyNever(() => addressFinder.findSecondary(any()));
+      verifyNever(() => creator.create(any(), any(), any()));
+    });
+
+    test('findSecondary failure sends error frame and closes', () async {
+      when(() => addressFinder.findSecondary('@bob'))
+          .thenThrow(Exception('not found'));
+
+      SecondaryWebSocketBridge(
+        dummyProxyUrl,
+        clientWs,
+        addressFinder,
+        _ctx(),
+        webSocketCreator: creator,
+      );
+
+      clientWs.controller.add('from:@bob\n');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(clientWs.sent.length, 2);
+      expect(clientWs.sent.first, '@');
+      expect(clientWs.sent.last, contains('not found'));
+      expect(clientWs.closeArgs?.code, WebSocketStatus.policyViolation);
+      verifyNever(() => creator.create(any(), any(), any()));
+    });
+
+    test('upstream connect failure sends error frame and closes', () async {
+      when(() => addressFinder.findSecondary('@alice'))
+          .thenAnswer((_) async => SecondaryAddress('secondary.example', 64));
+      when(() => creator.create(any(), any(), any()))
+          .thenThrow(SocketException('refused'));
+
+      SecondaryWebSocketBridge(
+        dummyProxyUrl,
+        clientWs,
+        addressFinder,
+        _ctx(),
+        webSocketCreator: creator,
+      );
+
+      clientWs.controller.add('from:@alice\n');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(clientWs.sent.length, 2);
+      expect(clientWs.sent.last, contains('refused'));
+      expect(clientWs.closeArgs?.code, WebSocketStatus.internalServerError);
+    });
+
+    test('buffer overflow before newline closes with policyViolation',
+        () async {
+      SecondaryWebSocketBridge(
+        dummyProxyUrl,
+        clientWs,
+        addressFinder,
+        _ctx(),
+        webSocketCreator: creator,
+      );
+
+      // Send > 511 bytes with no newline.
+      clientWs.controller.add('a' * 600);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(clientWs.sent, contains('Too much\n'));
+      expect(clientWs.closeArgs?.code, WebSocketStatus.policyViolation);
+      verifyNever(() => addressFinder.findSecondary(any()));
+    });
+  });
+
+  group('SecondaryWebSocketBridge open state', () {
+    late WebSocketMock clientWs;
+    late WebSocketMock upstreamWs;
+    late SecondaryAddressFinderMock addressFinder;
+    late WebSocketCreatorMock creator;
+
+    setUp(() async {
+      clientWs = _newClient();
+      upstreamWs = WebSocketMock();
+      addressFinder = SecondaryAddressFinderMock();
+      creator = WebSocketCreatorMock();
+
+      when(() => addressFinder.findSecondary('@alice'))
+          .thenAnswer((_) async => SecondaryAddress('secondary.example', 64));
+      when(() => creator.create(any(), any(), any()))
+          .thenAnswer((_) async => upstreamWs);
+
+      SecondaryWebSocketBridge(
+        dummyProxyUrl,
+        clientWs,
+        addressFinder,
+        _ctx(),
+        webSocketCreator: creator,
+      );
+      clientWs.controller.add('from:@alice\n');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      // Drop the bootstrap-forward and prompt frames so each test starts
+      // counting from a clean slate.
+      clientWs.sent.clear();
+      upstreamWs.sent.clear();
+    });
+
+    test('upstream text frames forwarded to client preserving frame type',
+        () async {
+      upstreamWs.controller.add('@');
+      upstreamWs.controller.add('data:proof:xyz\n@alice@');
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(clientWs.sent, equals(<dynamic>['@', 'data:proof:xyz\n@alice@']));
+      expect(clientWs.sent.every((e) => e is String), isTrue);
+    });
+
+    test('client binary frames forwarded as binary upstream', () async {
+      final binary = <int>[0xDE, 0xAD, 0xBE, 0xEF];
+      clientWs.controller.add(binary);
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(upstreamWs.sent, equals(<dynamic>[binary]));
+      expect(upstreamWs.sent.single, isA<List<int>>());
+    });
+
+    test('client text frames forwarded as text upstream', () async {
+      clientWs.controller.add('lookup:phone@alice\n');
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(upstreamWs.sent, equals(<dynamic>['lookup:phone@alice\n']));
+      expect(upstreamWs.sent.single, isA<String>());
+    });
+
+    test('upstream close tears down client', () async {
+      await upstreamWs.closeController();
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(clientWs.closeArgs, isNotNull);
+    });
+
+    test('client close tears down upstream', () async {
+      await clientWs.closeController();
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(upstreamWs.closeArgs, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
**- What I did**
Adds a new SecondaryWebSocketBridge that mirrors the existing SecondaryConnectionBridge handshake but at the WebSocket-frame layer. Inbound TLS connections that ALPN-negotiate http/1.1 and GET /ws are upgraded to a WebSocket; the bridge writes the @ prompt, waits for from:<atSign>\n (possibly across multiple text or binary frames), looks up the upstream atServer, opens an outbound wss://<atServer>/ws, and forwards frames bidirectionally preserving frame type. Errors during the handshake send a text frame and close with an appropriate WebSocket close code.

Also extracts the shared state machine, opening-state pipeline, done/error handlers, and teardown orchestration into a new SecondaryBridgeBase abstract class. Both bridge implementations now extend it and only supply transport-specific ops (prompt write, error write, close, secondary connect, frame forwarding, destroy).

Adds unit tests for the new bridge covering single- and multi-frame from: parsing, mixed text+binary accumulation, all four error paths, frame-type preservation in open state, and close propagation. Adds an integration test confirming the WebSocket dispatch path on the proxy server. All existing tests continue to pass.

**- How I did it**
See commits

**- How to verify it**
Tests pass. Will change from draft once I'm happy with local manual testing.