### PR TITLE
feat: at_secondary_proxy parsing

### DIFF
--- a/packages/at_secondary_proxy/bin/main.dart
+++ b/packages/at_secondary_proxy/bin/main.dart
@@ -57,15 +57,22 @@ SecondaryProxyServer _serverFromPositionalArgs(List<String> arguments) {
 SecondaryProxyServer _serverFromFlagArgs(List<String> arguments) {
   final parser = ArgParser()
     ..addOption('proxy-url',
-        help: 'Public-facing proxy address, e.g. vip.ve.atsign.zone:443')
+      mandatory: true,
+      help: 'Public-facing proxy address, e.g. vip.ve.atsign.zone:443')
     ..addOption('root-url',
-        help: 'atDirectory address, e.g. root.atsign.org:64')
+      mandatory: true,
+      help: 'upstream atDirectory address, e.g. vip.ve.atsign.zone:64')
     ..addOption('bind-port',
-        help: 'Local port to bind (defaults to the port in --proxy-url)')
+      mandatory: true,
+      help: 'Local port to bind (defaults to the port in --proxy-url)')
     ..addOption('cert-dir',
-        help: 'Directory containing fullchain.pem, privkey.pem, cacert.pem',
-        defaultsTo: 'certs')
-    ..addFlag('help', abbr: 'h', negatable: false, help: 'Show this help');
+      mandatory: false,
+      help: 'Directory containing fullchain.pem, privkey.pem, cacert.pem',
+      defaultsTo: 'certs')
+    ..addFlag('help', 
+      abbr: 'h',
+      negatable: false, 
+      help: 'Show this help');
 
   late final ArgResults results;
   try {
@@ -125,12 +132,12 @@ SecondaryProxyServer _serverFromFlagArgs(List<String> arguments) {
 }
 
 void _printUsage(ArgParser? parser) {
-  stderr.writeln('Usage (named):      at_proxyserver --proxy-url <host:port> --root-url <host:port> [--bind-port <port>] [--cert-dir <dir>]');
-  stderr.writeln('Usage (positional): at_proxyserver <proxy-url> <root-url> [bind-port]');
+  stderr.writeln('Usage:      at_proxyserver --proxy-url <host:port> --root-url <host:port> [--bind-port <port>] [--cert-dir <dir>]');
+  stderr.writeln('Usage (legacy): at_proxyserver <proxy-url> <root-url> [bind-port]');
   stderr.writeln('');
   stderr.writeln('Examples:');
-  stderr.writeln('  at_proxyserver --proxy-url vip.ve.atsign.zone:443 --root-url root.atsign.org:64 --bind-port 1443 --cert-dir /atsign/proxy/certs');
-  stderr.writeln('  at_proxyserver vip.ve.atsign.zone:443 root.atsign.org:64 1443');
+  stderr.writeln('  at_proxyserver --proxy-url vip.ve.atsign.zone:443 --root-url vip.ve.atsign.zone:64 --bind-port 1443 --cert-dir /atsign/proxy/certs');
+  stderr.writeln('  at_proxyserver vip.ve.atsign.zone:443 vip.ve.atsign.zone:64 1443');
   if (parser != null) {
     stderr.writeln('');
     stderr.writeln(parser.usage);

--- a/packages/at_secondary_proxy/bin/main.dart
+++ b/packages/at_secondary_proxy/bin/main.dart
@@ -1,42 +1,138 @@
+import 'dart:io';
+import 'package:args/args.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_secondary_proxy/at_secondary_proxy.dart';
-import 'dart:io';
-
-import 'package:at_utils/at_logger.dart' show AtSignLogger;
+import 'package:at_utils/at_logger.dart';
 
 Future<void> main(List<String> arguments) async {
-  String proxyUrl = 'vip.ve.atsign.zone:64';
-  String rootUrl = 'root.atsign.org:64';
-  String rootHost = 'root.atsign.org';
-  int proxyBindPort = 443;
-  int proxyListenPort = 443;
-  int rootPort = 64;
   AtSignLogger.defaultLoggingHandler = AtSignLogger.stdErrLoggingHandler;
-  try {
-    if (arguments.length == 2) {
-      proxyUrl = arguments[0];
-      rootUrl = arguments[1];
-    } else if (arguments.length == 3) {
-      proxyUrl = arguments[0];
-      rootUrl = arguments[1];
-      proxyBindPort = int.parse(arguments[2]);
-    } else {
-      error();
-    }
-    proxyListenPort = int.parse(proxyUrl.split(':')[1]);
-    rootHost = rootUrl.split(':')[0];
-    rootPort = int.parse(rootUrl.split(':')[1]);
-  } catch (e) {
-    error;
-  }
-  var server = SecondaryProxyServer(proxyUrl, proxyListenPort, proxyBindPort,
-      CacheableSecondaryAddressFinder(rootHost, rootPort));
+
+  final bool isPositional = arguments.isNotEmpty && !arguments[0].startsWith('-');
+
+  final SecondaryProxyServer server = isPositional
+      ? _serverFromPositionalArgs(arguments) // legacy
+      : _serverFromFlagArgs(arguments); // new flags (recommended usage)
+
   server.startServing();
 }
 
-void error() {
-  print(
-      'Usage: at_proxyserver <this proxies URL> <upstream atDirectory URL> [proxy bind port]');
-  print(' E.g. at_proxyserver vip.ve.atsign.zone:443 root.atsign.org:64 1443');
-  exit(1);
+SecondaryProxyServer _serverFromPositionalArgs(List<String> arguments) {
+  if (arguments.length < 2 || arguments.length > 3) {
+    _printUsage(null);
+    exit(1);
+  }
+
+  final String proxyUrl = arguments[0];
+  final String rootUrl = arguments[1];
+
+  int proxyBindPort = 443;
+  if (arguments.length == 3) {
+    proxyBindPort = int.tryParse(arguments[2]) ?? -1;
+    if (proxyBindPort == -1) {
+      stderr.writeln('Error: "${arguments[2]}" is not a valid port number');
+      exit(1);
+    }
+  }
+
+  final List<String> proxyParts = proxyUrl.split(':');
+  final List<String> rootParts = rootUrl.split(':');
+
+  if (proxyParts.length != 2 || int.tryParse(proxyParts[1]) == null) {
+    stderr.writeln('Error: invalid proxy-url "$proxyUrl" — expected host:port');
+    exit(1);
+  }
+  if (rootParts.length != 2 || int.tryParse(rootParts[1]) == null) {
+    stderr.writeln('Error: invalid root-url "$rootUrl" — expected host:port');
+    exit(1);
+  }
+
+  return SecondaryProxyServer(
+    proxyUrl,
+    int.parse(proxyParts[1]),
+    proxyBindPort,
+    CacheableSecondaryAddressFinder(rootParts[0], int.parse(rootParts[1])),
+  );
+}
+
+SecondaryProxyServer _serverFromFlagArgs(List<String> arguments) {
+  final parser = ArgParser()
+    ..addOption('proxy-url',
+        help: 'Public-facing proxy address, e.g. vip.ve.atsign.zone:443')
+    ..addOption('root-url',
+        help: 'atDirectory address, e.g. root.atsign.org:64')
+    ..addOption('bind-port',
+        help: 'Local port to bind (defaults to the port in --proxy-url)')
+    ..addOption('cert-dir',
+        help: 'Directory containing fullchain.pem, privkey.pem, cacert.pem',
+        defaultsTo: 'certs')
+    ..addFlag('help', abbr: 'h', negatable: false, help: 'Show this help');
+
+  late final ArgResults results;
+  try {
+    results = parser.parse(arguments);
+  } catch (e) {
+    stderr.writeln('Error: $e');
+    _printUsage(parser);
+    exit(1);
+  }
+
+  if (results['help'] as bool) {
+    _printUsage(parser);
+    exit(0);
+  }
+
+  final String proxyUrl = results['proxy-url'] as String? ?? '';
+  final String rootUrl = results['root-url'] as String? ?? '';
+  final String certDir = results['cert-dir'] as String;
+
+  if (proxyUrl.isEmpty || rootUrl.isEmpty) {
+    stderr.writeln('Error: --proxy-url and --root-url are required');
+    _printUsage(parser);
+    exit(1);
+  }
+
+  int proxyBindPort;
+  final String? bindPortStr = results['bind-port'] as String?;
+  if (bindPortStr != null) {
+    proxyBindPort = int.tryParse(bindPortStr) ?? -1;
+    if (proxyBindPort == -1) {
+      stderr.writeln('Error: "$bindPortStr" is not a valid port number');
+      exit(1);
+    }
+  } else {
+    proxyBindPort = int.tryParse(proxyUrl.split(':').last) ?? 443;
+  }
+
+  final List<String> proxyParts = proxyUrl.split(':');
+  final List<String> rootParts = rootUrl.split(':');
+
+  if (proxyParts.length != 2 || int.tryParse(proxyParts[1]) == null) {
+    stderr.writeln('Error: invalid proxy-url "$proxyUrl" — expected host:port');
+    exit(1);
+  }
+  if (rootParts.length != 2 || int.tryParse(rootParts[1]) == null) {
+    stderr.writeln('Error: invalid root-url "$rootUrl" — expected host:port');
+    exit(1);
+  }
+
+  return SecondaryProxyServer(
+    proxyUrl,
+    int.parse(proxyParts[1]),
+    proxyBindPort,
+    CacheableSecondaryAddressFinder(rootParts[0], int.parse(rootParts[1])),
+    certDir: certDir,
+  );
+}
+
+void _printUsage(ArgParser? parser) {
+  stderr.writeln('Usage (named):      at_proxyserver --proxy-url <host:port> --root-url <host:port> [--bind-port <port>] [--cert-dir <dir>]');
+  stderr.writeln('Usage (positional): at_proxyserver <proxy-url> <root-url> [bind-port]');
+  stderr.writeln('');
+  stderr.writeln('Examples:');
+  stderr.writeln('  at_proxyserver --proxy-url vip.ve.atsign.zone:443 --root-url root.atsign.org:64 --bind-port 1443 --cert-dir /atsign/proxy/certs');
+  stderr.writeln('  at_proxyserver vip.ve.atsign.zone:443 root.atsign.org:64 1443');
+  if (parser != null) {
+    stderr.writeln('');
+    stderr.writeln(parser.usage);
+  }
 }

--- a/packages/at_secondary_proxy/lib/src/secondary_proxy_server.dart
+++ b/packages/at_secondary_proxy/lib/src/secondary_proxy_server.dart
@@ -9,15 +9,12 @@ import 'secondary_connection_bridge.dart';
 import 'secondary_websocket_bridge.dart';
 
 class SecondaryProxyServer {
-  static final String _certificateChainLocation = 'certs/fullchain.pem';
-  static final String _privateKeyLocation = 'certs/privkey.pem';
-  static final String _trustedCertificateLocation = 'certs/cacert.pem';
-
   static final logger = AtSignLogger('AtSecondaryProxy');
 
   final int proxyPort;
   final int bindPort;
   final String proxyUrl;
+  final String certDir;
   final SecondaryAddressFinder secondaryAddressFinder;
   final ioClient = IOClient(HttpClient(context: _outboundHttpContext()));
 
@@ -36,15 +33,20 @@ class SecondaryProxyServer {
 
   bool get running => _running;
 
-  SecondaryProxyServer(this.proxyUrl, this.proxyPort, this.bindPort,
-      this.secondaryAddressFinder);
+  SecondaryProxyServer(
+    this.proxyUrl,
+    this.proxyPort,
+    this.bindPort,
+    this.secondaryAddressFinder, {
+    this.certDir = 'certs',
+  });
 
   void startServing() {
     SecurityContext serverContext = SecurityContext(withTrustedRoots: true);
 
-    serverContext.useCertificateChain(_certificateChainLocation);
-    serverContext.usePrivateKey(_privateKeyLocation);
-    serverContext.setTrustedCertificates(_trustedCertificateLocation);
+    serverContext.useCertificateChain('$certDir/fullchain.pem');
+    serverContext.usePrivateKey('$certDir/privkey.pem');
+    serverContext.setTrustedCertificates('$certDir/cacert.pem');
     serverContext.setAlpnProtocols(['atProtocol/1.0', 'http/1.1'], true);
     SecureServerSocket.bind(InternetAddress.anyIPv4, bindPort, serverContext)
         .then((SecureServerSocket secureServerSocket) {

--- a/packages/at_secondary_proxy/pubspec.lock
+++ b/packages/at_secondary_proxy/pubspec.lock
@@ -26,7 +26,7 @@ packages:
     source: hosted
     version: "4.0.7"
   args:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: args
       sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
@@ -674,4 +674,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"

--- a/packages/at_secondary_proxy/pubspec.yaml
+++ b/packages/at_secondary_proxy/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   at_utils: ^3.4.0
   at_lookup: ^3.5.0
   http: ^1.6.0
+  args: ^2.7.0
 
 dev_dependencies:
   lints: ^6.1.0


### PR DESCRIPTION
closes #193 

**- What I did**
- Added an `ArgParser` to at_secondary_proxy
- Positional arguments remain functional

**- How I did it**
- Using Claude

**- How to verify it**
- See comments on sample runs

**- Description for the changelog**
feat: at_secondary_proxy argument parsing
