### PR TITLE
build(deps): Bump Dart to 3.12.0

### DIFF
--- a/packages/at_secondary_proxy/tools/Dockerfile
+++ b/packages/at_secondary_proxy/tools/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile
 # Build image for a containerized call of the at_proxyserver binary in scratch container
 # default certs included but mount /atsign/certs for certs and caroot
-FROM dart:3.11.2@sha256:f379cd388f850db3833823244f5b66c2b23ad739876467e8a3dfa72706e3eee9 AS buildimage
+FROM dart:3.12.0@sha256:3d1b19886b288807b42020ede8f1f9ea7753c91c17c27479ee9e7bf584289a34 AS buildimage
 ENV PACKAGEDIR=packages/at_secondary_proxy
 ENV HOMEDIR=/atsign
 ENV WORKDIR=/app


### PR DESCRIPTION
Dependabot has not been bumping Dart :(

**- What I did**

Bump to 3.12.0

**- How I did it**

Copied line from a Dependabot PR to another repo

**- How to verify it**

CI

**- Description for the changelog**

build(deps): Bump Dart to 3.12.0
